### PR TITLE
[requirements-ci] add pymor and wurlitzer

### DIFF
--- a/constraints/requirements-ci.txt
+++ b/constraints/requirements-ci.txt
@@ -9,6 +9,7 @@ flake8-docstrings
 flake8-rst-docstrings
 hypothesis[numpy,pytest]>=6.10
 nbconvert
+pymor
 pybind11
 pypi-oldest-requirements>=2021.2
 pytest-cov
@@ -20,3 +21,4 @@ pytest>=6.0
 readme_renderer[md]
 rstcheck
 twine
+wurlitzer


### PR DESCRIPTION
Just a test if we can abuse this here to quickly generate pypi cache images for the dune-gdt tutorials. Please delete as you see fit, @renefritze!