### PR TITLE
Set lower bound for scipy version in python 3.8

### DIFF
--- a/constraints/requirements.txt
+++ b/constraints/requirements.txt
@@ -6,7 +6,7 @@ numpy>=1.19.4;python_version >= "3.9"
 packaging
 pytest-runner>=2.9
 qtpy>2.0
-scipy>=1.3.3;python_version == "3.8"
+scipy>=1.5.0;python_version == "3.8"
 scipy>=1.3;python_version < "3.8"
 scipy>=1.5.4;python_version >= "3.9"
 setuptools


### PR DESCRIPTION
See https://github.com/pymor/pymor/pull/1871